### PR TITLE
Added API for tracking visibility of video frames

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@
 
 buildscript {
     ext {
-        kotlin_version = '1.2.41'
+        kotlin_version = '1.2.51'
         support_version = '27.1.1'
-        exo_version = '2.7.1'
+        exo_version = '2.7.3'
     }
     repositories {
         google()

--- a/renderer/build.gradle
+++ b/renderer/build.gradle
@@ -24,6 +24,10 @@ android {
                 'FISH_EYE_RENDERER'   : "com.onemobilesdk.videorenderer.fisheye@$version"
         ]
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {

--- a/renderer/proguard-rules.pro
+++ b/renderer/proguard-rules.pro
@@ -4,6 +4,8 @@
 -keepparameternames
 -renamesourcefileattribute SourceFile
 
+-dontwarn java.lang.invoke.**
+
 -dontnote com.google.android.gms.**
 -dontnote android.net.http.**
 -dontnote android.support.**

--- a/renderer/src/main/java/com/aol/mobile/sdk/renderer/internal/GlEsRendererView.java
+++ b/renderer/src/main/java/com/aol/mobile/sdk/renderer/internal/GlEsRendererView.java
@@ -46,23 +46,13 @@ public final class GlEsRendererView extends GLSurfaceView {
     }
 
     public void dispose() {
-        queueEvent(new Runnable() {
-            @Override
-            public void run() {
-                renderer.dispose();
-            }
-        });
+        queueEvent(renderer::dispose);
     }
 
     public void setCameraOrientation(final double longitude, final double latitude) {
         if (longitude == this.longitude && latitude == this.latitude) return;
         this.longitude = longitude;
         this.latitude = latitude;
-        queueEvent(new Runnable() {
-            @Override
-            public void run() {
-                renderer.setCameraOrientation(longitude, latitude);
-            }
-        });
+        queueEvent(() -> renderer.setCameraOrientation(longitude, latitude));
     }
 }

--- a/renderer/src/main/java/com/aol/mobile/sdk/renderer/viewmodel/VideoVM.java
+++ b/renderer/src/main/java/com/aol/mobile/sdk/renderer/viewmodel/VideoVM.java
@@ -119,6 +119,16 @@ public class VideoVM {
          */
         void onTrackInfoAvailable(@NonNull List<AudioTrack> audioTrackList, @NonNull List<TextTrack> textTrackList);
 
+        /**
+         * Fired when actual frame of video is visible to user.
+         */
+        void onVideoFrameVisible();
+
+        /**
+         * Fired when no video frames can be presented to user.
+         */
+        void onVideoFrameGone();
+
         enum Error {
             /**
              * Bad internet or slow, timed out connection error.


### PR DESCRIPTION
## Frame visibility API [JIRA ticket](https://jira.ops.aol.com/browse/OMSDK-1386)

For better UX we need to track visibility of videos frame rendered to user. This will allow us to avoid unnecessary **black** screens when video is buffering.

This PR also contains following minor changes:
 - **ExoPlayer** version bumped to `2.7.3`
 - **Java** source code version bumped to `1.8`
 - **Kotlin** version to `1.2.51`
 - **ExoPlayer**s factories for playback source construction made local variables in order to improve `GC` work
 - Actual video playback callback logic reworked

@OlegKozhemiakin @YaroslavKryvko Please, review.